### PR TITLE
Change dependency to latest Magento version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "type": "magento2-theme",
     "require": {
-        "magento/framework": "101.0.*"
+        "magento/framework": "102.0.*"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Needs tagging to 3.0 for Magento version 102 (otherwise known as Magento 2.3).